### PR TITLE
refactor(gateway): add ProxyService, centralize proxy logic, simplify…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,160 @@
 # CortexAI Copilot Instructions
 
+## Project Overview
+Monorepo with microservices: client (Next.js), gateway (NestJS), auth (NestJS), report-service (NestJS).
+Shared packages: `@cortex/shared` (types, schemas), `@cortex/backend-common` (filters, interceptors).
+
+## Frontend Libraries (client/)
+
+### Next.js 16 + React 19
+- Use App Router (`src/app/`), not Pages Router
+- Server Components by default, add `"use client"` only when needed (hooks, state, refs)
+- React Compiler enabled — keep components pure
+
+### React Hook Form v7 + Zod
+```typescript
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { loginSchema, LoginDtoType } from '@cortex/shared';
+
+const form = useForm<LoginDtoType>({
+  resolver: zodResolver(loginSchema),
+  defaultValues: { email: '', password: '' },
+});
+```
+- Always use `zodResolver` with schemas from `@cortex/shared`
+- Prefer `register()` for simple inputs, `Controller` for complex (select, datepicker)
+
+### TanStack Query v5
+```typescript
+import { useQuery, useMutation } from '@tanstack/react-query';
+
+// Queries - use array keys
+const { data } = useQuery({
+  queryKey: ['users', userId],
+  queryFn: () => fetchUser(userId),
+});
+
+// Mutations - invalidate on success
+const mutation = useMutation({
+  mutationFn: createUser,
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+});
+```
+
+### Axios
+- HTTP client configured in `src/services/http/`
+- Use `httpFactory.createAuthClient()` for authenticated requests
+- Use `httpFactory.createPublicClient()` for public requests
+- Proxy through `/api/proxy` for CSR to handle cookies
+
+### Tailwind CSS v4
+- Use `@import "tailwindcss";` and `@theme inline` syntax
+- Prefer semantic tokens: `bg-card`, `text-muted-foreground`, `border-border`
+- Dark mode via `darkMode: "class"` on `<html>`
+
+### Other Frontend
+- **lucide-react**: Icon library, import individually `import { User } from 'lucide-react'`
+- **next-themes**: Theme switching, use `useTheme()` hook
+- **react-hot-toast**: Notifications, use `toast.success()`, `toast.error()`
+
+## Backend Libraries (auth/, gateway/)
+
+### NestJS 11
+- Modular architecture: `*.module.ts`, `*.controller.ts`, `*.service.ts`
+- Use Dependency Injection via constructor
+- Guards for auth: `@UseGuards(AtGuard)`
+- Pipes for validation: `ZodValidationPipe` globally applied
+
+### Prisma 7
+```typescript
+// New config format in prisma.config.ts (not schema.prisma url)
+import { defineConfig } from 'prisma/config';
+export default defineConfig({
+  datasource: { url: process.env.DATABASE_URL },
+});
+
+// Service pattern
+@Injectable()
+export class UsersService {
+  constructor(private prisma: PrismaService) {}
+  
+  findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+}
+```
+
+### Passport JWT + Argon2
+- Access token: short-lived (1h), in Authorization header
+- Refresh token: long-lived (7d), hashed with Argon2 in DB
+- Use `@nestjs/passport` with `passport-jwt` strategy
+
+### nestjs-zod
+- Validation pipe: `app.useGlobalPipes(new ZodValidationPipe())`
+- DTOs extend Zod schemas from `@cortex/shared`
+- Swagger integration via `@asteasolutions/zod-to-openapi`
+
+### Throttler + Redis
+```typescript
+ThrottlerModule.forRoot({
+  throttlers: [{ ttl: 60000, limit: 10 }],
+  storage: new ThrottlerStorageRedisService(new Redis({ host, port })),
+})
+```
+
+### Other Backend
+- **helmet**: Security headers, `app.use(helmet())`
+- **@nestjs/swagger**: Auto-generate API docs at `/api`
+- **@nestjs/axios**: HTTP client for service-to-service calls
+- **cookie-parser**: Parse cookies for refresh token flow
+
+## Shared Package (@cortex/shared)
+
+### Zod Schemas
+```typescript
+// Always import from shared, not define locally
+import { loginSchema, registerSchema, LoginDtoType } from '@cortex/shared';
+```
+
+### Constants
+```typescript
+import { AppErrors, ApiRoutes } from '@cortex/shared';
+// AppErrors.AUTH.INVALID_CREDENTIALS
+// ApiRoutes.AUTH.LOGIN
+```
+
+## Code Style
+
+- TypeScript strict mode enabled
+- Prefer `const` over `let`
+- Use async/await, not callbacks
+- Error handling: throw NestJS exceptions (`UnauthorizedException`, etc.)
+- Logging: use `Logger` from `@nestjs/common`
+
+## File Structure Conventions
+
+```
+src/
+├── app/              # Next.js routes (client)
+├── components/       # React components
+├── services/         # API clients, business logic
+├── modules/          # NestJS modules (backend)
+│   └── auth/
+│       ├── auth.module.ts
+│       ├── auth.controller.ts
+│       ├── auth.service.ts
+│       └── dto/
+└── common/           # Shared utilities per service
+    ├── guards/
+    ├── filters/
+    └── interceptors/
+```
+
+---
+
+## Original Frontend Instructions
+
 - Stack: Next.js 16 (App Router) with React 19, Tailwind CSS v4, TypeScript, next-themes, and React Compiler enabled in `next.config.ts`.
 - Entrypoint layout: `src/app/layout.tsx` loads Montserrat via `next/font`, wraps children in the custom `ThemeProvider`, and exposes metadata (title/description). Keep the `html` tag `suppressHydrationWarning` and preserve the theme wrapper when adding pages.
 - Theming: `src/components/provider/themeProvider.component.tsx` is a thin `next-themes` wrapper; default theme is `purple` with allowed themes `light`, `dark`, `purple`. Use `className="bg-background text-foreground ..."` style tokens; they map to CSS variables defined per theme in `src/app/globals.css`.

--- a/gateway/src/app.module.ts
+++ b/gateway/src/app.module.ts
@@ -1,4 +1,5 @@
-import { Module } from '@nestjs/common';
+import { Module, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
+import { CorrelationIDMiddleware } from '@cortex/backend-common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ThrottlerModule, ThrottlerModuleOptions } from '@nestjs/throttler';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
@@ -62,4 +63,10 @@ import { ReportsModule } from './modules/reports/reports.module';
     }),
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(CorrelationIDMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
+  }
+}

--- a/gateway/src/common/services/proxy.service.ts
+++ b/gateway/src/common/services/proxy.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, Logger, HttpException } from '@nestjs/common';
+import axios, { AxiosResponse } from 'axios';
+import { Response } from 'express';
+
+@Injectable()
+export class ProxyService {
+  private readonly logger = new Logger(ProxyService.name);
+
+  async forwardRequest<T = unknown>(
+    axiosRequest: () => Promise<AxiosResponse<T>>,
+    res: Response,
+    options?: {
+      forwardSetCookie?: boolean;
+      logCorrelationId?: string;
+    },
+  ): Promise<T> {
+    try {
+      const response = await axiosRequest();
+      if (options?.forwardSetCookie && response.headers['set-cookie']) {
+        this.forwardSetCookieHeaders(response.headers['set-cookie'], res);
+      }
+      return response.data;
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        const axiosError = error;
+        const message = axiosError.message || 'Downstream service unavailable';
+        this.logger.error(
+          `Proxy error: ${message}` +
+            (options?.logCorrelationId ? ` [${options.logCorrelationId}]` : ''),
+        );
+        if (axiosError.response) {
+          throw new HttpException(
+            (axiosError.response.data as string | object | undefined) ||
+              message,
+            axiosError.response.status || 500,
+          );
+        }
+        throw new HttpException(message, 503);
+      }
+      throw new HttpException('Unexpected proxy error', 500);
+    }
+  }
+
+  forwardSetCookieHeaders(
+    setCookieHeader: string[] | string,
+    res: Response,
+  ): void {
+    if (Array.isArray(setCookieHeader) && setCookieHeader.length > 0) {
+      res.setHeader('Set-Cookie', setCookieHeader);
+    } else if (
+      typeof setCookieHeader === 'string' &&
+      setCookieHeader.length > 0
+    ) {
+      res.setHeader('Set-Cookie', [setCookieHeader]);
+    }
+  }
+}

--- a/gateway/src/modules/auth/auth.controller.ts
+++ b/gateway/src/modules/auth/auth.controller.ts
@@ -1,14 +1,7 @@
-import {
-  Body,
-  Controller,
-  HttpException,
-  Logger,
-  Post,
-  Res,
-  UsePipes,
-} from '@nestjs/common';
+import { Body, Controller, Post, Req, Res, UsePipes } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
+import { ProxyService } from '../../common/services/proxy.service';
 import {
   AuthResponseDto,
   LoginDto,
@@ -17,17 +10,16 @@ import {
 import { firstValueFrom } from 'rxjs';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { ApiResponse } from '@nestjs/swagger';
-import axios, { AxiosError } from 'axios';
 import type { Response } from 'express';
 
 @Controller('auth')
 export class AuthController {
-  private readonly logger = new Logger(AuthController.name);
   private readonly authServiceUrl: string;
 
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
+    private readonly proxyService: ProxyService,
   ) {
     this.authServiceUrl =
       this.configService.get<string>('AUTH_SERVICE_URL') ??
@@ -50,34 +42,27 @@ export class AuthController {
   async login(
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) res: Response,
+    @Req() req: Request & { correlationID?: string },
   ): Promise<AuthResponseDto> {
-    try {
-      const authResponse = await firstValueFrom(
-        this.httpService.post<AuthResponseDto>(
-          `${this.authServiceUrl}/auth/login`,
-          loginDto,
+    const correlationId =
+      req.correlationID ||
+      (req.headers['x-correlation-id'] as string | undefined);
+    return this.proxyService.forwardRequest<AuthResponseDto>(
+      () =>
+        firstValueFrom(
+          this.httpService.post<AuthResponseDto>(
+            `${this.authServiceUrl}/auth/login`,
+            loginDto,
+            {
+              headers: {
+                ...(correlationId ? { 'X-Correlation-ID': correlationId } : {}),
+              },
+            },
+          ),
         ),
-      );
-      this.forwardSetCookieHeaders(authResponse.headers['set-cookie'], res);
-      return authResponse.data;
-    } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        const axiosError: AxiosError = error;
-        const message = axiosError.message || 'Auth service is unavailable';
-        this.logger.error(`AuthService request failed: ${message}`);
-
-        if (axiosError.response) {
-          throw new HttpException(
-            axiosError.response.data || message,
-            axiosError.response.status || 500,
-          );
-        }
-
-        throw new HttpException(message, 503);
-      }
-
-      throw new HttpException('Unexpected auth gateway error', 500);
-    }
+      res,
+      { forwardSetCookie: true, logCorrelationId: correlationId },
+    );
   }
 
   @Post('register')
@@ -93,47 +78,26 @@ export class AuthController {
   async register(
     @Body() registerDto: RegisterDto,
     @Res({ passthrough: true }) res: Response,
+    @Req() req: Request & { correlationID?: string },
   ): Promise<AuthResponseDto> {
-    try {
-      const authResponse = await firstValueFrom(
-        this.httpService.post<AuthResponseDto>(
-          `${this.authServiceUrl}/auth/register`,
-          registerDto,
+    const correlationId =
+      req.correlationID ||
+      (req.headers['x-correlation-id'] as string | undefined);
+    return this.proxyService.forwardRequest<AuthResponseDto>(
+      () =>
+        firstValueFrom(
+          this.httpService.post<AuthResponseDto>(
+            `${this.authServiceUrl}/auth/register`,
+            registerDto,
+            {
+              headers: {
+                ...(correlationId ? { 'X-Correlation-ID': correlationId } : {}),
+              },
+            },
+          ),
         ),
-      );
-      this.forwardSetCookieHeaders(authResponse.headers['set-cookie'], res);
-      return authResponse.data;
-    } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        const axiosError: AxiosError = error;
-        const message = axiosError.message || 'Auth service is unavailable';
-        this.logger.error(`AuthService request failed: ${message}`);
-
-        if (axiosError.response) {
-          throw new HttpException(
-            axiosError.response.data || message,
-            axiosError.response.status || 500,
-          );
-        }
-
-        throw new HttpException(message, 503);
-      }
-
-      throw new HttpException('Unexpected auth gateway error', 500);
-    }
-  }
-
-  private forwardSetCookieHeaders(
-    setCookieHeader: string[] | string | undefined,
-    res: Response,
-  ): void {
-    if (Array.isArray(setCookieHeader) && setCookieHeader.length > 0) {
-      res.setHeader('Set-Cookie', setCookieHeader);
-      return;
-    }
-
-    if (typeof setCookieHeader === 'string' && setCookieHeader.length > 0) {
-      res.setHeader('Set-Cookie', [setCookieHeader]);
-    }
+      res,
+      { forwardSetCookie: true, logCorrelationId: correlationId },
+    );
   }
 }

--- a/gateway/src/modules/auth/auth.module.ts
+++ b/gateway/src/modules/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ProxyService } from '../../common/services/proxy.service';
 import { AuthController } from './auth.controller';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from '@nestjs/axios';
@@ -6,5 +7,6 @@ import { HttpModule } from '@nestjs/axios';
 @Module({
   controllers: [AuthController],
   imports: [ConfigModule, HttpModule],
+  providers: [ProxyService],
 })
 export class AuthModule {}

--- a/gateway/src/modules/reports/reports.controller.ts
+++ b/gateway/src/modules/reports/reports.controller.ts
@@ -1,5 +1,6 @@
 import { HttpService } from '@nestjs/axios';
-import { Controller, Logger, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { ProxyService } from '../../common/services/proxy.service';
 import { ConfigService } from '@nestjs/config';
 import {
   ApiBearerAuth,
@@ -10,21 +11,14 @@ import {
 import type { Request, Response } from 'express';
 import { UploadResponseDto } from 'src/common/dto/reports.dto';
 import { AtGuard } from 'src/common/guards/at.guard';
-import { AxiosError } from 'axios';
-import { Readable } from 'stream';
-
-const MAX_ERROR_BODY_SIZE = 1024 * 1024; // 1MB limit for error responses
-
-// TODO: Add file size limit guard/middleware to prevent oversized uploads
-// Consider using Content-Length header check or streaming byte counter
 
 @Controller('reports')
 export class ReportsController {
-  private readonly logger = new Logger(ReportsController.name);
   private readonly reportsUrl: string;
   constructor(
     private readonly configService: ConfigService,
     private readonly httpService: HttpService,
+    private readonly proxyService: ProxyService,
   ) {
     this.reportsUrl =
       this.configService.get<string>('REPORTS_SERVICE_URL') ??
@@ -61,80 +55,33 @@ export class ReportsController {
   })
   @ApiResponse({ status: 500, description: 'Internal Server Error.' })
   async createReportTemplate(
-    @Req() req: Request & { user: { userId: string; email: string } },
+    @Req()
+    req: Request & {
+      user: { userId: string; email: string };
+      correlationID?: string;
+    },
     @Res() res: Response,
   ): Promise<void> {
     const userId = req.user.userId;
-
-    const headers: Record<string, any> = { ...req.headers };
-
-    delete headers['content-length'];
-    delete headers['host'];
-    delete headers['connection'];
-    delete headers['transfer-encoding'];
+    let correlationId = req.correlationID || req.headers['x-correlation-id'];
+    if (Array.isArray(correlationId)) correlationId = correlationId[0];
+    const headers: Record<string, string | string[] | undefined> = {
+      ...req.headers,
+    };
     headers['X-User-Id'] = userId;
+    if (correlationId) headers['X-Correlation-ID'] = correlationId;
 
-    try {
-      const response = await this.httpService.axiosRef({
-        method: 'POST',
-        url: `${this.reportsUrl}/templates/template`,
-        data: req,
-        responseType: 'stream',
-        headers: headers,
-      });
-
-      res.status(response.status);
-
-      Object.keys(response.headers).forEach((key) => {
-        res.setHeader(key, response.headers[key]);
-      });
-
-      (response.data as Readable).pipe(res);
-    } catch (err) {
-      const error = err as AxiosError<unknown>;
-
-      if (error.response) {
-        const responseData = error.response.data;
-
-        if (responseData instanceof Readable) {
-          const errorBuffer: Buffer[] = [];
-          let totalSize = 0;
-
-          for await (const chunk of responseData) {
-            const buffer = Buffer.from(chunk as ArrayBuffer);
-            totalSize += buffer.length;
-
-            if (totalSize > MAX_ERROR_BODY_SIZE) {
-              responseData.destroy();
-              res.status(502).json({
-                message: 'Error response from service exceeded size limit',
-              });
-              return;
-            }
-
-            errorBuffer.push(buffer);
-          }
-          const errorString = Buffer.concat(errorBuffer).toString('utf8');
-          try {
-            const errorJson: unknown = JSON.parse(errorString);
-            this.logger.error('Service error (JSON):', errorJson);
-
-            res.status(error.response.status).json(errorJson);
-          } catch {
-            this.logger.error('Service error (TEXT):', errorString);
-
-            res.status(error.response.status).send(errorString);
-          }
-          return;
-        }
-
-        this.logger.error('Service error:', error.response.data);
-
-        res.status(error.response.status).json(error.response.data);
-      } else {
-        this.logger.error('Gateway critical error:', error.message);
-        res.status(500).json({ message: error.message });
-      }
-    }
+    await this.proxyService.forwardRequest(
+      () =>
+        this.httpService.axiosRef({
+          method: 'POST',
+          url: `${this.reportsUrl}/templates/template`,
+          data: req,
+          responseType: 'stream',
+          headers,
+        }),
+      res,
+      { forwardSetCookie: false, logCorrelationId: correlationId },
+    );
   }
 }

--- a/gateway/src/modules/reports/reports.module.ts
+++ b/gateway/src/modules/reports/reports.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ProxyService } from '../../common/services/proxy.service';
 import { ReportsController } from './reports.controller';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from '@nestjs/axios';
@@ -14,6 +15,6 @@ import { PassportModule } from '@nestjs/passport';
     JwtModule.register({}),
     PassportModule.register({ defaultStrategy: 'jwt' }),
   ],
-  providers: [AtStrategy],
+  providers: [AtStrategy, ProxyService],
 })
 export class ReportsModule {}


### PR DESCRIPTION
Що зроблено
Винесено всю логіку проксирування HTTP-запитів у окремий ProxyService.
Централізовано обробку помилок, cookies та логування correlationId.
Контролери auth/report спрощені: тепер лише делегують запити через ProxyService.
Дотримано принципів SRP та DRY, зменшено дублювання коду.
Всі типи та обробка unknown/any приведені до strict-стилю (type assertion, явні типи).