### PR TITLE
fix(http-exception-filter): add service name to error logs

### DIFF
--- a/backend-common/src/filters/httpException.filter.ts
+++ b/backend-common/src/filters/httpException.filter.ts
@@ -52,8 +52,12 @@ export class HttpExceptionFilter implements ExceptionFilter {
       correlationID,
     };
 
+    const service = process.env.npm_package_name || process.env.SERVICE_NAME || 'unknown-service';
+
+
+
     this.logger.error(
-      `[${status}] ${request.method} ${request.url} - Error: ${JSON.stringify(message)}`,
+      `[${service}] [${status}] ${request.method} ${request.url} - Error: ${JSON.stringify({ ...errorResponse, service })}`,
       exception instanceof Error ? exception.stack : String(exception)
     );
 


### PR DESCRIPTION
Що зроблено
Додано поле service до логів у HttpExceptionFilter (але не у response клієнту).
Тепер у логах помилок видно, з якого саме сервісу виникла помилка (для зручного дебагу в мікросервісній архітектурі).